### PR TITLE
bugfix/32: Change pre-commit and lint-staged commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,12 +43,13 @@
 	},
 	"husky": {
 		"hooks": {
-			"pre-commit": "npm test && lint-staged && git add --all"
+			"pre-commit": "npm test && lint-staged"
 		}
 	},
 	"lint-staged": {
 		"*.{js,jsx}": [
-			"prettier --config .prettierrc --write"
+			"prettier --config .prettierrc --write",
+			"git add"
 		]
 	},
 	"jest": {


### PR DESCRIPTION
Pre-commit hooks and lint-staged commands will only commit the files that are staged, rather than adding all files.

**Link to Issue**:

-   #32 

**Readiness**:

-   [x] Connect this Pull Request to an issue
-   [x] Unit test component functionalities
-   [x] Use semantic HTML tags
-   [x] Avoid duplicated logic
