### PR TITLE
fix: Root isAuthenticated from redux

### DIFF
--- a/client/src/Routes.jsx
+++ b/client/src/Routes.jsx
@@ -1,6 +1,7 @@
 import React, { Suspense, lazy } from 'react';
 import PropTypes from 'prop-types';
 import { HashRouter, Route, Switch } from 'react-router-dom';
+import { connect } from 'react-redux';
 
 import AppContainer from './components/AppContainer';
 import Loader from './components/Shared/Loader/Loader';
@@ -112,4 +113,8 @@ Routes.propTypes = {
 	isAuthenticated: PropTypes.bool.isRequired,
 };
 
-export default Routes;
+const mapStateToProps = ({ auth }) => ({
+	isAuthenticated: auth.isAuthenticated,
+});
+
+export default connect(mapStateToProps)(Routes);

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -13,8 +13,6 @@ import store from './store/store';
 import { logoutUser, setCurrentUser } from './actions/authActions';
 import { getHabits } from './actions/habitActions';
 
-let isAuthenticated = false;
-
 const history = createHistory({
 	hashType: 'noslash',
 });
@@ -34,7 +32,6 @@ if (localStorage.jwtToken) {
 		// Redirect to login
 		history.push('/auth/login');
 	} else {
-		isAuthenticated = true;
 		// Set user and isAuthenticated
 		store.dispatch(setCurrentUser(decoded));
 		// Get user's habits
@@ -45,7 +42,7 @@ if (localStorage.jwtToken) {
 const Root = () => (
 	<Provider store={store}>
 		<GlobalStyle />
-		<Routes isAuthenticated={isAuthenticated} />
+		<Routes />
 	</Provider>
 );
 


### PR DESCRIPTION
The app was checking for a JWT token on mount, but only on mount. This would mean that if the user was not logged in, and then logged in, the isAuthenticated prop would only be passed down when the root component was mounted (on a page reload).

This fixes that issue by removing the isAuthenticated prop from the root component, and passing it as a prop from Redux state into the routes component.

The root component still checks for a JWT token on mount and dispatches an action to Redux to authenticate the user. 


**Link to Issue**:

-   Fixes/Closes #93 

**Readiness**:

-   [x] Avoid duplicated logic
-   [ ] Unit test component functionalities
-   [x] Use semantic HTML tags
-   [x] Use [semantic commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
-   [x] Connect this Pull Request to an issue
