### PR TITLE
Test/119: Login and register unit tests

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -100,7 +100,8 @@
 		"moxios": "^0.4.0",
 		"prettier": "^1.14.2",
 		"prop-types": "^15.6.2",
-		"react-hot-loader": "^4.6.2"
+		"react-hot-loader": "^4.6.2",
+		"redux-mock-store": "^1.5.3"
 	},
 	"proxy": "http://localhost:8080"
 }

--- a/client/src/actions/authActions.js
+++ b/client/src/actions/authActions.js
@@ -8,22 +8,6 @@ import setAuthToken from '../utils/setAuthToken';
 
 const { SET_CURRENT_USER, GET_ERRORS, EDIT_PROFILE, ADD_FRIEND } = Types;
 
-// Register user
-export const registerUser = (userData, history) => dispatch =>
-	axios
-		.post('api/auth/register', userData)
-		.then(() => {
-			history.push('/auth/login');
-			toast.success('Successfully registered, go ahead and log in!');
-		})
-		.catch(err => {
-			toast.error('Oops! There was a problem registering...');
-			dispatch({
-				type: GET_ERRORS,
-				payload: err.response.data,
-			});
-		});
-
 // Set logged in user
 export const setCurrentUser = decoded => ({
 	type: SET_CURRENT_USER,
@@ -52,6 +36,22 @@ export const loginUser = (userData, history) => dispatch =>
 		.then(() => history.push('/dashboard'))
 		.catch(err => {
 			toast.error('Oops! There was a problem logging in...');
+			dispatch({
+				type: GET_ERRORS,
+				payload: err.response.data,
+			});
+		});
+
+// Register user
+export const registerUser = (userData, history) => dispatch =>
+	axios
+		.post('api/auth/register', userData)
+		.then(() => {
+			toast.success('Successfully registered!');
+			dispatch(loginUser(userData, history));
+		})
+		.catch(err => {
+			toast.error('Oops! There was a problem registering...');
 			dispatch({
 				type: GET_ERRORS,
 				payload: err.response.data,

--- a/client/src/actions/authActions.js
+++ b/client/src/actions/authActions.js
@@ -1,18 +1,11 @@
 import axios from 'axios';
-// eslint-disable-next-line camelcase
-import jwt_decode from 'jwt-decode';
+import jwtDecode from 'jwt-decode';
 import { toast } from 'react-toastify';
 import Types from './types';
 import { getHabits } from './habitActions';
 import setAuthToken from '../utils/setAuthToken';
 
 const { SET_CURRENT_USER, GET_ERRORS, EDIT_PROFILE, ADD_FRIEND } = Types;
-
-// Set logged in user
-export const setCurrentUser = decoded => ({
-	type: SET_CURRENT_USER,
-	payload: decoded,
-});
 
 // Login - get user token
 export const loginUser = (userData, history) => dispatch =>
@@ -25,9 +18,12 @@ export const loginUser = (userData, history) => dispatch =>
 			// Set token to auth header
 			setAuthToken(token);
 			// Decode token for user data
-			const decoded = jwt_decode(token);
+			const decoded = jwtDecode(token);
 			// Set current user
-			dispatch(setCurrentUser(decoded));
+			dispatch({
+				type: SET_CURRENT_USER,
+				payload: decoded,
+			});
 			// Get user's habits
 			dispatch(getHabits());
 			// Display success message
@@ -65,7 +61,10 @@ export const logoutUser = history => dispatch => {
 	// Remove auth header for future requests
 	setAuthToken(null);
 	// Set current user to {} - this sets isAuthenticated to false
-	dispatch(setCurrentUser({}));
+	dispatch({
+		type: SET_CURRENT_USER,
+		payload: {},
+	});
 	// Redirect to homepage
 	history.push('/');
 	// Success toast message

--- a/client/src/actions/authActions.js
+++ b/client/src/actions/authActions.js
@@ -7,6 +7,12 @@ import setAuthToken from '../utils/setAuthToken';
 
 const { SET_CURRENT_USER, GET_ERRORS, EDIT_PROFILE, ADD_FRIEND } = Types;
 
+// Set logged in user
+export const setCurrentUser = decoded => ({
+	type: SET_CURRENT_USER,
+	payload: decoded,
+});
+
 // Login - get user token
 export const loginUser = (userData, history) => dispatch =>
 	axios

--- a/client/src/actions/authActions.test.js
+++ b/client/src/actions/authActions.test.js
@@ -3,9 +3,30 @@ import moxios from 'moxios';
 import { createTestStore } from '../utils/testUtils';
 import { addFriend } from './authActions';
 
+describe('registerUser action creator', () => {
+	beforeEach(() => {
+		moxios.install();
+	});
+	afterEach(() => {
+		moxios.uninstall();
+	});
+
+	it('registers user on success', () => {});
+});
+
+describe('loginUser action creator', () => {
+	beforeEach(() => {
+		moxios.install();
+	});
+	afterEach(() => {
+		moxios.uninstall();
+	});
+
+	it('logs user in on success', () => {});
+});
+
 describe('addFriend action creator', () => {
 	beforeEach(() => {
-		// moxios will intercept requests during the test
 		moxios.install();
 	});
 	afterEach(() => {

--- a/client/src/actions/authActions.test.js
+++ b/client/src/actions/authActions.test.js
@@ -12,15 +12,15 @@ describe('registerUser action creator', () => {
 	});
 
 	const historyMock = { push: () => null };
+	const mockUser = {
+		name: 'Tester',
+		email: 'test@test.com',
+		avatar: 'https://avatar.com/avatar.gif',
+		password: 'password',
+	};
 
 	it('returns an error on failure', () => {
 		const store = createTestStore();
-		const mockUser = {
-			name: 'Tester',
-			email: 'test@test.com',
-			avatar: 'https://avatar.com/avatar.gif',
-			password: 'password',
-		};
 		const mockError = {
 			email: 'Email is already in use',
 		};
@@ -39,12 +39,6 @@ describe('registerUser action creator', () => {
 	});
 	it('registers user and returns no action (directly)', () => {
 		const store = createMockStore();
-		const mockUser = {
-			name: 'Tester',
-			email: 'test@test.com',
-			avatar: 'https://avatar.com/avatar.gif',
-			password: 'password',
-		};
 
 		moxios.wait(() => {
 			const request = moxios.requests.mostRecent();
@@ -70,13 +64,13 @@ describe('loginUser action creator', () => {
 	});
 
 	const historyMock = { push: () => null };
+	const mockUser = {
+		email: 'test@test.com',
+		password: 'password',
+	};
 
 	it('returns an error on failure', () => {
 		const store = createTestStore();
-		const mockUser = {
-			email: 'test@test.com',
-			password: 'password',
-		};
 		const mockError = {
 			email: 'A user with that email does not exist',
 		};
@@ -96,10 +90,6 @@ describe('loginUser action creator', () => {
 	});
 	it('logs user in on success', () => {
 		const store = createMockStore();
-		const mockUser = {
-			email: 'test@test.com',
-			password: 'password',
-		};
 		const mockToken =
 			'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjVjYjc0MjQ2OWRhMjNhOWUzOWFiYzE1YyIsIm5hbWUiOiJ0ZXN0ZXIiLCJlbWFpbCI6InRlc3RAdGVzdC5jb20iLCJhdmF0YXIiOiJodHRwczovLy8vd3d3LmdyYXZhdGFyLmNvbS9hdmF0YXIvYjY0MmI0MjE3YjM0YjFlOGQzYmQ5MTVmYzY1YzQ0NTI_cz0yMDAmcj1wZyZkPW1wIiwiYWJvdXQiOmZhbHNlLCJnb2FscyI6W10sImZyaWVuZHMiOltdLCJpYXQiOjE1NTU1MTM5MzUsImV4cCI6MTU1NTUxNzUzNX0.cIJjHzRYhguJmE9TrDn56o0ctKFH7IZYNIcpRBbim1Y';
 

--- a/client/src/components/AddFriend/AddFriend.test.jsx
+++ b/client/src/components/AddFriend/AddFriend.test.jsx
@@ -3,10 +3,10 @@ import { shallow } from 'enzyme';
 
 import { _AddFriend as AddFriend } from './AddFriend';
 
-const setup = (mountFn, initialProps = {}) => {
-	const props = { errors: {}, addFriend: () => null, ...initialProps };
+const setup = (mountFn, customProps = {}) => {
+	const initialProps = { errors: {}, addFriend: () => null };
 
-	const wrapper = mountFn(<AddFriend {...props} />);
+	const wrapper = mountFn(<AddFriend {...initialProps} {...customProps} />);
 	return wrapper;
 };
 

--- a/client/src/components/Auth/Login/Login.jsx
+++ b/client/src/components/Auth/Login/Login.jsx
@@ -9,7 +9,7 @@ import { TopText, ContentArea, Footer } from '../Auth.styled';
 import FormGroup from '../../Shared/Forms/FormGroup';
 import { Button } from '../../Shared/Forms/Form.styled';
 
-class Login extends Component {
+export class _Login extends Component {
 	state = {
 		email: '',
 		password: '',
@@ -44,7 +44,7 @@ class Login extends Component {
 	};
 
 	handleSubmit = e => {
-		e.preventDefault();
+		if (e) e.preventDefault();
 		// eslint-disable-next-line no-shadow
 		const { loginUser, history } = this.props;
 		const { errors, ...newUser } = this.state;
@@ -112,4 +112,4 @@ const mapStateToProps = state => ({
 export default connect(
 	mapStateToProps,
 	{ loginUser }
-)(withRouter(Login));
+)(withRouter(_Login));

--- a/client/src/components/Auth/Login/Login.test.jsx
+++ b/client/src/components/Auth/Login/Login.test.jsx
@@ -1,26 +1,94 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import Login from './Login';
+import { _Login as Login } from './Login';
 
-describe('Login', () => {
-	const setup = fullMount => {
-		const props = {};
-		let component;
-		if (fullMount) {
-			component = fullMount(<Login {...props} />);
-		} else {
-			component = shallow(<Login {...props} />);
-		}
-
-		return {
-			props,
-			component,
-		};
+const setup = (mountFn, customProps = {}) => {
+	const initialProps = {
+		loginUser: () => null,
+		errors: {},
+		auth: {
+			isAuthenticated: false,
+			user: {},
+		},
 	};
 
-	test('it does math', () => {
-		setup();
-		expect(2 + 2).toBe(4);
+	const wrapper = mountFn(<Login {...initialProps} {...customProps} />);
+	return wrapper;
+};
+
+describe('Login already authenticated', () => {
+	let wrapper;
+	const authProps = {
+		isAuthenticated: true,
+		user: {},
+	};
+	const historyMock = {
+		replace: jest.fn(),
+	};
+
+	beforeEach(() => {
+		wrapper = setup(shallow, { auth: authProps, history: historyMock });
+	});
+
+	it('renders without error', () => {
+		expect(wrapper).toBeTruthy();
+	});
+	it('redirects', () => {
+		expect(historyMock.replace).toHaveBeenCalled();
+	});
+});
+
+describe('Login without auth', () => {
+	let wrapper;
+	const loginUser = jest.fn();
+
+	beforeEach(() => {
+		wrapper = setup(shallow, { loginUser });
+	});
+
+	it('calls loginUser fn on submit', () => {
+		const form = wrapper.find('form');
+		expect(form).toBeTruthy();
+		form.prop('onSubmit')();
+		expect(loginUser).toHaveBeenCalled();
+	});
+	it('passes input state to loginUser fn', () => {
+		const form = wrapper.find('form');
+		const newState = { email: 'test@tester.com', password: 'password' };
+		wrapper.setState(newState);
+		expect(wrapper.state('email')).toBe(newState.email);
+		form.prop('onSubmit')();
+		expect(loginUser).toHaveBeenCalledWith(newState, undefined);
+	});
+});
+
+describe('Login with errors', () => {
+	let wrapper;
+	const error = {
+		email: "We couldn't find a user with email tester@test.com",
+		password: 'Incorrect password',
+	};
+
+	beforeEach(() => {
+		wrapper = setup(shallow, {
+			errors: error,
+		});
+	});
+
+	it('sends the error to the email FormGroup component', () => {
+		const emailFormGroup = wrapper
+			.find('FormGroup')
+			.filterWhere(group => group.prop('name') === 'email');
+		expect(emailFormGroup.length).toBe(1);
+		expect(emailFormGroup.prop('errors')).toEqual(error.email);
+	});
+
+	it('sends the error to the password FormGroup component', () => {
+		const passwordFormGroup = wrapper
+			.find('FormGroup')
+			.filterWhere(group => group.prop('name') === 'password');
+		expect(passwordFormGroup.length).toBe(1);
+		expect(passwordFormGroup.prop('errors')).toEqual(error.password);
 	});
 });

--- a/client/src/components/Auth/Register/Register.jsx
+++ b/client/src/components/Auth/Register/Register.jsx
@@ -9,7 +9,7 @@ import { TopText, ContentArea, Footer } from '../Auth.styled';
 import FormGroup from '../../Shared/Forms/FormGroup';
 import { Button } from '../../Shared/Forms/Form.styled';
 
-class Register extends Component {
+export class _Register extends Component {
 	state = {
 		name: '',
 		email: '',
@@ -48,7 +48,7 @@ class Register extends Component {
 	};
 
 	handleSubmit = e => {
-		e.preventDefault();
+		if (e) e.preventDefault();
 		// eslint-disable-next-line no-shadow
 		const { registerUser, history } = this.props;
 		const { errors, ...newUser } = this.state;
@@ -140,4 +140,4 @@ const mapStateToProps = state => ({
 export default connect(
 	mapStateToProps,
 	{ registerUser }
-)(withRouter(Register));
+)(withRouter(_Register));

--- a/client/src/components/Auth/Register/Register.test.jsx
+++ b/client/src/components/Auth/Register/Register.test.jsx
@@ -1,26 +1,99 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import Register from './Register';
+import { _Register as Register } from './Register';
 
-describe('Register', () => {
-	const setup = fullMount => {
-		const props = {};
-		let component;
-		if (fullMount) {
-			component = fullMount(<Register {...props} />);
-		} else {
-			component = shallow(<Register {...props} />);
-		}
-
-		return {
-			props,
-			component,
-		};
+const setup = (mountFn, customProps = {}) => {
+	const initialProps = {
+		registerUser: () => null,
+		errors: {},
+		auth: {
+			isAuthenticated: false,
+			user: {},
+		},
 	};
 
-	test('it does math', () => {
-		setup();
-		expect(2 + 2).toBe(4);
+	const wrapper = mountFn(<Register {...initialProps} {...customProps} />);
+	return wrapper;
+};
+
+describe('Register already authenticated', () => {
+	let wrapper;
+	const authProps = {
+		isAuthenticated: true,
+		user: {},
+	};
+	const historyMock = {
+		replace: jest.fn(),
+	};
+
+	beforeEach(() => {
+		wrapper = setup(shallow, { auth: authProps, history: historyMock });
+	});
+
+	it('renders without error', () => {
+		expect(wrapper).toBeTruthy();
+	});
+	it('redirects', () => {
+		expect(historyMock.replace).toHaveBeenCalled();
+	});
+});
+
+describe('Register without auth', () => {
+	let wrapper;
+	const registerUser = jest.fn();
+
+	beforeEach(() => {
+		wrapper = setup(shallow, { registerUser });
+	});
+
+	it('calls registerUser fn on submit', () => {
+		const form = wrapper.find('form');
+		expect(form).toBeTruthy();
+		form.prop('onSubmit')();
+		expect(registerUser).toHaveBeenCalled();
+	});
+	it('passes input state to registerUser fn', () => {
+		const form = wrapper.find('form');
+		const newState = {
+			email: 'test@tester.com',
+			name: 'tester',
+			password: 'password',
+			password2: 'password',
+		};
+		wrapper.setState(newState);
+		expect(wrapper.state('email')).toBe(newState.email);
+		form.prop('onSubmit')();
+		expect(registerUser).toHaveBeenCalledWith(newState, undefined);
+	});
+});
+
+describe('Register with errors', () => {
+	let wrapper;
+	const error = {
+		email: "We couldn't find a user with email tester@test.com",
+		password: 'Incorrect password',
+	};
+
+	beforeEach(() => {
+		wrapper = setup(shallow, {
+			errors: error,
+		});
+	});
+
+	it('sends the error to the email FormGroup component', () => {
+		const emailFormGroup = wrapper
+			.find('FormGroup')
+			.filterWhere(group => group.prop('name') === 'email');
+		expect(emailFormGroup.length).toBe(1);
+		expect(emailFormGroup.prop('errors')).toEqual(error.email);
+	});
+
+	it('sends the error to the password FormGroup component', () => {
+		const passwordFormGroup = wrapper
+			.find('FormGroup')
+			.filterWhere(group => group.prop('name') === 'password');
+		expect(passwordFormGroup.length).toBe(1);
+		expect(passwordFormGroup.prop('errors')).toEqual(error.password);
 	});
 });

--- a/client/src/utils/testUtils.js
+++ b/client/src/utils/testUtils.js
@@ -1,4 +1,5 @@
 import { createStore, applyMiddleware } from 'redux';
+import configureStore from 'redux-mock-store';
 import rootReducer from '../reducers/combineReducers';
 import { middleware } from '../store/store';
 
@@ -6,3 +7,5 @@ export const createTestStore = initialState => {
 	const createStoreWithMiddleware = applyMiddleware(...middleware)(createStore);
 	return createStoreWithMiddleware(rootReducer, initialState);
 };
+
+export const createMockStore = configureStore(middleware);


### PR DESCRIPTION
Unit tests for the Login and Register components, as well as the login and register Redux action creators.

There is a `createTestStore()` function in test utils which can be used to create an actual redux store for testing. This is useful for testing state changes on the store.

This PR also adds the `redux-mock-store` library. This is useful to test whether particular actions are called on the store, but because it is a mock it does not hold actual state.

**Link to Issue**:

-   Fixes/Closes #119 

**Readiness**:

-   [x] Avoid duplicated logic
-   [x] Unit test component functionalities
-   [x] Use semantic HTML tags
-   [x] Use [semantic commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
-   [x] Connect this Pull Request to an issue
